### PR TITLE
Fix admin list page

### DIFF
--- a/osmo/admin.py
+++ b/osmo/admin.py
@@ -71,7 +71,7 @@ def rem(slide_name):
     :rtype: :class:`flask.Response`
     """
 
-    name = werkzeug.utils.secure_filename(name)
+    name = werkzeug.utils.secure_filename(slide_name)
     try:
         os.remove(os.path.join(media_dir, name))
     except OSError as e:

--- a/osmo/templates/admin/index.html
+++ b/osmo/templates/admin/index.html
@@ -67,7 +67,7 @@
             <td>{{ slide.end }}</td>
             <td>{{ slide.duration }}</td>
           <td>
-              <a href="{{ url_for('rem', name=slide.name) }}" role="button"><i class="icon-remove"></i></a>
+              <a href="{{ url_for('rem', slide_name=slide.name) }}" role="button"><i class="icon-remove"></i></a>
           </td>
         </tr>
       {% endfor %}


### PR DESCRIPTION
The 'name' argument to the rem call is now called 'slide_name'.
